### PR TITLE
Use .net 6 in github action

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
       working-directory: src/Server


### PR DESCRIPTION
Please also include the change to the github action, to build with .net 6 instead of .net 5